### PR TITLE
Version 3.6.3

### DIFF
--- a/check/checkers.go
+++ b/check/checkers.go
@@ -149,6 +149,10 @@ func checkForLineLength(id string, s *spec.Spec) []Alert {
 				continue
 			}
 
+			if strings.IndexRune(strutil.Substr(line.Text, 2, 999), ' ') == -1 {
+				continue
+			}
+
 			if strutil.Len(line.Text) > 80 {
 				result = append(result, NewAlert(id, LEVEL_WARNING, "Line is longer than 80 symbols", line))
 			}

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -33,7 +33,7 @@ import (
 // App info
 const (
 	APP  = "Perfecto"
-	VER  = "3.6.2"
+	VER  = "3.6.3"
 	DESC = "Tool for checking perfectly written RPM specs"
 )
 

--- a/common/perfecto.spec
+++ b/common/perfecto.spec
@@ -14,7 +14,7 @@
 
 Summary:         Tool for checking perfectly written RPM specs
 Name:            perfecto
-Version:         3.6.2
+Version:         3.6.3
 Release:         0%{?dist}
 Group:           Development/Tools
 License:         Apache License, Version 2.0
@@ -96,6 +96,9 @@ fi
 ################################################################################
 
 %changelog
+* Fri Apr 02 2021 Anton Novojilov <andy@essentialkaos.com> - 3.6.3-0
+- Ignore links longer than 80 symbols in PF2
+
 * Fri Feb 26 2021 Anton Novojilov <andy@essentialkaos.com> - 3.6.2-0
 - Fixed bash completion
 - Fixed zsh completion

--- a/testdata/test_1.spec
+++ b/testdata/test_1.spec
@@ -62,3 +62,4 @@ rm -rf %{buildroot}
 %changelog
 * Wed Jan 24 2018 Anton Novojilov <andy@essentialkaos.com> - 1.0.0-0
 - At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium
+- https://github.com/organization/project/issues?q=milestone:versionAlpha+label:ReadyForReview


### PR DESCRIPTION
#### Improvements
* Ignore links longer than 80 symbols in [PF2](https://kaos.sh/perfecto/w/PF2)
