### PR TITLE
Fix micro docker image

### DIFF
--- a/micro.docker
+++ b/micro.docker
@@ -1,6 +1,6 @@
 ## BUILDER #####################################################################
 
-FROM golang:alpine as builder
+FROM golang:alpine3.13 as builder
 
 WORKDIR /go/src/github.com/essentialkaos/perfecto
 
@@ -8,7 +8,7 @@ COPY . .
 
 ENV GO111MODULE=auto
 
-RUN apk add --no-cache git=~2.32 make=4.3-r0 upx=3.96-r1 && \
+RUN apk add --no-cache git=~2.30 make=4.3-r0 upx=3.96-r1 && \
     make deps && \
     make all && \
     upx perfecto


### PR DESCRIPTION
Fixed micro docker image, which can not be built on the latest Alpine (`3.14`) due to bug with [faccessat2](https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396).